### PR TITLE
Implement stdout exporter

### DIFF
--- a/src/exporters/mod.rs
+++ b/src/exporters/mod.rs
@@ -1,3 +1,36 @@
 //! Data exporters.
-pub mod influxdb;
-pub mod stdout;
+use std::io;
+
+use crossbeam_channel::Receiver;
+
+mod influxdb;
+mod stdout;
+
+pub use stdout::Stdout;
+
+pub struct Exporter<T>
+where
+    T: Sink,
+{
+    sink: T,
+}
+
+impl<T> Exporter<T>
+where
+    T: Sink,
+{
+    pub fn new(sink: T) -> Exporter<T> {
+        Exporter { sink }
+    }
+
+    pub fn start(&self, receiver: Receiver<&str>) {
+        loop {
+            let data = receiver.recv().unwrap();
+            self.sink.export(data).unwrap();
+        }
+    }
+}
+
+pub trait Sink {
+    fn export(&self, data: &str) -> Result<(), io::Error>;
+}

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -1,0 +1,18 @@
+use std::io;
+
+use super::Sink;
+
+pub struct Stdout {}
+
+impl Stdout {
+    pub fn new() -> Stdout {
+        Stdout {}
+    }
+}
+
+impl Sink for Stdout {
+    fn export(&self, data: &str) -> Result<(), io::Error> {
+        println!("{}", data);
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,12 @@
 use std::process;
 use std::{thread, time::Duration};
 
-use crossbeam_channel::{unbounded, Receiver, Sender};
+use crossbeam_channel::{unbounded, Sender};
 
 mod exporters;
 mod receivers;
+
+use exporters::{Exporter, Stdout};
 
 fn main() {
     println!("wiperf started");
@@ -18,25 +20,18 @@ fn main() {
     let (s, r) = unbounded();
 
     // Ping
-    thread::spawn(move || send_stuff(s));
+    let thread1 = thread::spawn(move || send_stuff(s));
     // Stdout
-    thread::spawn(move || receive_stuff(r));
+    let exporter = Exporter::new(Stdout::new());
+    let thread2 = thread::spawn(move || exporter.start(r));
 
-    loop {
-        thread::sleep(Duration::from_secs(1));
-    }
+    thread1.join().expect("The sender thread has panicked");
+    thread2.join().expect("The receiver thread has panicked");
 }
 
 fn send_stuff(s: Sender<&str>) {
     loop {
         s.send("Hi!").unwrap();
-        thread::sleep(Duration::from_secs(1));
-    }
-}
-
-fn receive_stuff(r: Receiver<&str>) {
-    loop {
-        println!("Received: {:?}", r.recv());
         thread::sleep(Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
I thought I would not touch this code today but I couldn't wait :smile: I made `Sink` a trait so we can easily implement new exporters by just implementing `Sink` trait for them.

My idea is that the sinks just implement the functionality to send data to different sinks. `Exporter` receives messages and later it can have functionality to buffer messages or retry sending them.

We probably want to do something similar with "tools".
