### PR TITLE
Improve Message implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ checksum = "80094f509cf8b5ae86a4966a39b3ff66cd7e2a3e594accec3743ff3fabeab5b2"
 dependencies = [
  "num-integer",
  "num-traits",
+ "serde",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ edition = "2018"
 [dependencies]
 ctrlc = "3.1"
 crossbeam-channel = "0.4"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.3"
 url = "2.1.1"
-http_req  = {version="0.6", default-features = false, features = ["rust-tls"]}
+http_req  = { version = "0.6", default-features = false, features = ["rust-tls"] }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,19 +1,25 @@
-use serde::{Deserialize, Serialize};
 use std::fmt;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Message {
+    timestamp: DateTime<Utc>,
     payload: String,
 }
 
 impl Message {
     pub fn new(payload: String) -> Message {
-        Message { payload }
+        Message {
+            timestamp: Utc::now(),
+            payload,
+        }
     }
 }
 
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.payload)
+        write!(f, "{}, {}", self.timestamp.to_rfc3339(), self.payload)
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -6,13 +6,15 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Message {
     timestamp: DateTime<Utc>,
+    source: String,
     payload: String,
 }
 
 impl Message {
-    pub fn new(payload: String) -> Message {
+    pub fn new(source: String, payload: String) -> Message {
         Message {
             timestamp: Utc::now(),
+            source,
             payload,
         }
     }
@@ -20,6 +22,12 @@ impl Message {
 
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}, {}", self.timestamp.to_rfc3339(), self.payload)
+        write!(
+            f,
+            "[{}, source={}] {}",
+            self.timestamp.to_rfc3339(),
+            self.source,
+            self.payload
+        )
     }
 }

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,33 +1,165 @@
+use std::collections::HashMap;
 use std::fmt;
 
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Debug)]
 pub struct Message {
     timestamp: DateTime<Utc>,
     source: String,
-    payload: String,
+    payload: HashMap<String, PayloadValue>,
 }
 
 impl Message {
-    pub fn new(source: String, payload: String) -> Message {
+    pub fn new(source: &str) -> Message {
         Message {
             timestamp: Utc::now(),
-            source,
-            payload,
+            source: String::from(source),
+            payload: HashMap::new(),
         }
+    }
+
+    pub fn insert_data(&mut self, field: &str, value: impl Into<PayloadValue>) {
+        self.payload.insert(String::from(field), value.into());
     }
 }
 
 impl fmt::Display for Message {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut payload = String::new();
+        for (key, value) in self.payload.iter() {
+            payload.push_str(&format!(" {}={}", key, value));
+        }
+
         write!(
             f,
-            "[{}, source={}] {}",
+            "[{}, source={}]{}",
             self.timestamp.to_rfc3339(),
             self.source,
-            self.payload
+            payload
         )
+    }
+}
+
+#[derive(Serialize, Debug)]
+pub enum PayloadValue {
+    String(String),
+    Int8(i8),
+    Int16(i16),
+    Int32(i32),
+    Int64(i64),
+    Int128(i128),
+    Uint8(u8),
+    Uint16(u16),
+    Uint32(u32),
+    Uint64(u64),
+    Uint128(u128),
+    Float32(f32),
+    Float64(f64),
+}
+
+impl From<&String> for PayloadValue {
+    fn from(item: &String) -> Self {
+        PayloadValue::String(item.clone())
+    }
+}
+
+impl From<&str> for PayloadValue {
+    fn from(item: &str) -> Self {
+        PayloadValue::String(item.to_owned())
+    }
+}
+
+impl From<&i8> for PayloadValue {
+    fn from(item: &i8) -> Self {
+        PayloadValue::Int8(item.clone())
+    }
+}
+
+impl From<&i16> for PayloadValue {
+    fn from(item: &i16) -> Self {
+        PayloadValue::Int16(item.clone())
+    }
+}
+
+impl From<&i32> for PayloadValue {
+    fn from(item: &i32) -> Self {
+        PayloadValue::Int32(item.clone())
+    }
+}
+
+impl From<&i64> for PayloadValue {
+    fn from(item: &i64) -> Self {
+        PayloadValue::Int64(item.clone())
+    }
+}
+
+impl From<&i128> for PayloadValue {
+    fn from(item: &i128) -> Self {
+        PayloadValue::Int128(item.clone())
+    }
+}
+
+impl From<&u8> for PayloadValue {
+    fn from(item: &u8) -> Self {
+        PayloadValue::Uint8(item.clone())
+    }
+}
+
+impl From<&u16> for PayloadValue {
+    fn from(item: &u16) -> Self {
+        PayloadValue::Uint16(item.clone())
+    }
+}
+
+impl From<&u32> for PayloadValue {
+    fn from(item: &u32) -> Self {
+        PayloadValue::Uint32(item.clone())
+    }
+}
+
+impl From<&u64> for PayloadValue {
+    fn from(item: &u64) -> Self {
+        PayloadValue::Uint64(item.clone())
+    }
+}
+
+impl From<&u128> for PayloadValue {
+    fn from(item: &u128) -> Self {
+        PayloadValue::Uint128(item.clone())
+    }
+}
+
+impl From<&f32> for PayloadValue {
+    fn from(item: &f32) -> Self {
+        PayloadValue::Float32(item.clone())
+    }
+}
+
+impl From<&f64> for PayloadValue {
+    fn from(item: &f64) -> Self {
+        PayloadValue::Float64(item.clone())
+    }
+}
+
+impl fmt::Display for PayloadValue {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let value = match self {
+            PayloadValue::String(val) => val.to_owned(),
+            PayloadValue::Int8(val) => val.to_string(),
+            PayloadValue::Int16(val) => val.to_string(),
+            PayloadValue::Int32(val) => val.to_string(),
+            PayloadValue::Int64(val) => val.to_string(),
+            PayloadValue::Int128(val) => val.to_string(),
+            PayloadValue::Uint8(val) => val.to_string(),
+            PayloadValue::Uint16(val) => val.to_string(),
+            PayloadValue::Uint32(val) => val.to_string(),
+            PayloadValue::Uint64(val) => val.to_string(),
+            PayloadValue::Uint128(val) => val.to_string(),
+            PayloadValue::Float32(val) => val.to_string(),
+            PayloadValue::Float64(val) => val.to_string(),
+        };
+        write!(f, "{}", value)
     }
 }

--- a/src/receivers/http.rs
+++ b/src/receivers/http.rs
@@ -40,15 +40,12 @@ impl Collector for HTTP {
             .timeout(timeout)
             .read_timeout(timeout)
             .send(&mut writer)?;
-        let duration = now.elapsed().as_millis();
+        let latency = now.elapsed().as_millis();
 
-        Ok(Message::new(
-            "http".to_string(),
-            String::from(format!(
-                "HTTP request took {} ms and returned with status {}",
-                duration.to_string(),
-                resp.status_code()
-            )),
-        ))
+        let mut message = Message::new("http");
+        message.insert_data("latency", &latency);
+        message.insert_data("status_code", &resp.status_code().to_string());
+
+        Ok(message)
     }
 }

--- a/src/receivers/http.rs
+++ b/src/receivers/http.rs
@@ -42,10 +42,13 @@ impl Collector for HTTP {
             .send(&mut writer)?;
         let duration = now.elapsed().as_millis();
 
-        Ok(Message::new(String::from(format!(
-            "HTTP request took {} ms and returned with status {}",
-            duration.to_string(),
-            resp.status_code()
-        ))))
+        Ok(Message::new(
+            "http".to_string(),
+            String::from(format!(
+                "HTTP request took {} ms and returned with status {}",
+                duration.to_string(),
+                resp.status_code()
+            )),
+        ))
     }
 }

--- a/src/receivers/ping.rs
+++ b/src/receivers/ping.rs
@@ -37,11 +37,14 @@ fn execute_ping_on_command_line(ping: &Ping) -> String {
 
 fn parse_ping_output_to_message(ping_output: String) -> Message {
     let lines: Vec<&str> = ping_output.lines().rev().collect();
-    Message::new(format!(
-        "packets: {} rtt: {}",
-        parse_packets_line(lines[1]),
-        parse_rtt_line(lines[0])
-    ))
+    Message::new(
+        "ping".to_string(),
+        format!(
+            "packets: {} rtt: {}",
+            parse_packets_line(lines[1]),
+            parse_rtt_line(lines[0])
+        ),
+    )
 }
 
 fn parse_packets_line(text: &str) -> String {


### PR DESCRIPTION
Changes:
- Added timestamp to `Message`.
- Added source to `Message`.
- Implemented payload as a `HashMap` so it is possible to add multiple values to the payload.

Right now it is only possible to add `String` fields to the payload. Later if needed, we could implement adding, for example, integer fields so the exporters could take advantage of that.

This closes #21.