### PR TITLE
Improve naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ This tool was inspired by [wiperf](https://github.com/wifinigel/wiperf) project.
 
 ### Features
 
-Uption has a concept of _receivers_ and _exporters_. Receivers generate metrics based on different tests and exporters export the generated data.
+Uption has a concept of _collectors_ and _exporters_. Collectors generate metrics based on different tests and exporters export the generated data.
 
 #### Exporters
 
 - [x] Stdout
 - [x] InfluxDB
 
-#### Receivers
+#### Collectors
 
 - [x] HTTP
 - [x] Ping
@@ -29,7 +29,7 @@ Uption has a concept of _receivers_ and _exporters_. Receivers generate metrics 
 - [ ] JSON file ([issue #11](https://github.com/uption/uption/issues/11))
 - [ ] CSV file ([issue #12](https://github.com/uption/uption/issues/12))
 
-#### Receivers
+#### Collectors
 
 - [ ] DHCP ([issue #14](https://github.com/uption/uption/issues/14))
 - [ ] DNS ([issue #15](https://github.com/uption/uption/issues/15))

--- a/src/collectors/error.rs
+++ b/src/collectors/error.rs
@@ -2,22 +2,22 @@ use std::error;
 use std::fmt;
 
 #[derive(Debug, Clone)]
-pub enum ReceiverError {
+pub enum CollectorError {
     ConnectionError(String),
     CollectionError(String),
 }
 
-impl fmt::Display for ReceiverError {
+impl fmt::Display for CollectorError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let err = match self {
-            ReceiverError::ConnectionError(err) => format!("ConnectionError: {}", err),
-            ReceiverError::CollectionError(err) => format!("CollectionError: {}", err),
+            CollectorError::ConnectionError(err) => format!("ConnectionError: {}", err),
+            CollectorError::CollectionError(err) => format!("CollectionError: {}", err),
         };
         write!(f, "{}", err)
     }
 }
 
-impl error::Error for ReceiverError {
+impl error::Error for CollectorError {
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         None
     }

--- a/src/collectors/http.rs
+++ b/src/collectors/http.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 use http_req::error::Error as HttpError;
 use http_req::request::{Method, Request};
 
-use super::error::ReceiverError;
+use super::error::CollectorError;
 use super::Collector;
 use crate::message::Message;
 use crate::url::HttpUrl;
@@ -19,19 +19,19 @@ impl HTTP {
     }
 }
 
-impl From<HttpError> for ReceiverError {
+impl From<HttpError> for CollectorError {
     fn from(error: HttpError) -> Self {
         let err = match error {
             HttpError::IO(err) => err.to_string(),
             HttpError::Tls => String::from("TLS error"),
-            HttpError::Parse(err) => return ReceiverError::CollectionError(err.to_string()),
+            HttpError::Parse(err) => return CollectorError::CollectionError(err.to_string()),
         };
-        ReceiverError::ConnectionError(format!("{}", err))
+        CollectorError::ConnectionError(format!("{}", err))
     }
 }
 
 impl Collector for HTTP {
-    fn collect(&self) -> Result<Message, ReceiverError> {
+    fn collect(&self) -> Result<Message, CollectorError> {
         let mut writer = Vec::new();
 
         let now = Instant::now();

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -1,4 +1,4 @@
-//! Data receivers.
+//! Data collectors.
 mod error;
 mod http;
 mod ping;
@@ -8,18 +8,18 @@ use std::{thread, time::Duration};
 use crossbeam_channel::Sender;
 
 use crate::message::Message;
-pub use error::ReceiverError;
+pub use error::CollectorError;
 pub use http::HTTP;
 pub use ping::Ping;
 
-pub struct Receiver {
+pub struct CollectorScheduler {
     collectors: Vec<Box<dyn Collector + Send>>,
     interval: Duration,
 }
 
-impl Receiver {
-    pub fn new(interval: u64) -> Receiver {
-        Receiver {
+impl CollectorScheduler {
+    pub fn new(interval: u64) -> CollectorScheduler {
+        CollectorScheduler {
             collectors: Vec::new(),
             interval: Duration::from_secs(interval),
         }
@@ -31,10 +31,10 @@ impl Receiver {
 
     pub fn start(&self, sender: Sender<Message>) {
         if self.collectors.is_empty() {
-            println!("No receivers configured!");
+            println!("No collectors configured!");
             return;
         }
-        println!("Collection scheduler started");
+        println!("Collector scheduler started");
 
         loop {
             for collector in self.collectors.iter() {
@@ -53,5 +53,5 @@ impl Receiver {
 }
 
 pub trait Collector {
-    fn collect(&self) -> Result<Message, ReceiverError>;
+    fn collect(&self) -> Result<Message, CollectorError>;
 }

--- a/src/collectors/ping.rs
+++ b/src/collectors/ping.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 use regex::Regex;
 
-use super::error::ReceiverError;
+use super::error::CollectorError;
 use super::Collector;
 use crate::message::Message;
 use crate::url::Host;
@@ -19,7 +19,7 @@ impl Ping {
 }
 
 impl Collector for Ping {
-    fn collect(&self) -> Result<Message, ReceiverError> {
+    fn collect(&self) -> Result<Message, CollectorError> {
         let ping_output = execute_ping_on_command_line(self);
         Ok(parse_ping_output_to_message(ping_output))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 #[derive(Debug, Deserialize)]
 pub struct UptionConfig {
     pub general: GeneralConfig,
-    pub receivers: ReceiversConfig,
+    pub collectors: CollectorsConfig,
     pub exporters: ExportersConfig,
 }
 
@@ -14,7 +14,7 @@ pub struct GeneralConfig {
     hostname: String,
 }
 #[derive(Debug, Deserialize)]
-pub struct ReceiversConfig {
+pub struct CollectorsConfig {
     pub interval: u64,
     pub ping: PingConfig,
     pub http: HttpConfig,

--- a/src/exporters/influxdb.rs
+++ b/src/exporters/influxdb.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use http_req::request::{Method, Request};
 use http_req::response::{Response, StatusCode};
 
-use super::Sink;
+use super::Exporter;
 use crate::message::Message;
 use crate::url::HttpUrl;
 
@@ -70,7 +70,7 @@ impl InfluxDB {
     }
 }
 
-impl Sink for InfluxDB {
+impl Exporter for InfluxDB {
     fn export(&self, msg: &Message) -> Result<(), io::Error> {
         let payload = self.message_to_line_protocol(&msg);
         let resp = self.send_request(&payload);

--- a/src/exporters/stdout.rs
+++ b/src/exporters/stdout.rs
@@ -1,6 +1,6 @@
 use std::io;
 
-use super::Sink;
+use super::Exporter;
 use crate::message::Message;
 
 pub struct Stdout {}
@@ -11,7 +11,7 @@ impl Stdout {
     }
 }
 
-impl Sink for Stdout {
+impl Exporter for Stdout {
     fn export(&self, msg: &Message) -> Result<(), io::Error> {
         println!("{}", msg);
         Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
+mod collectors;
 mod config;
 mod exporters;
 mod message;
-mod receivers;
 mod uption;
 mod url;
 

--- a/src/uption.rs
+++ b/src/uption.rs
@@ -2,9 +2,9 @@ use std::thread;
 
 use crossbeam_channel::unbounded;
 
+use crate::collectors::{CollectorScheduler, Ping, HTTP};
 use crate::config::{ExporterSelection, UptionConfig};
 use crate::exporters::{ExporterScheduler, InfluxDB, Stdout};
-use crate::receivers::{Ping, Receiver, HTTP};
 
 pub struct Uption {
     config: UptionConfig,
@@ -19,16 +19,16 @@ impl Uption {
         println!("Uption started");
         let (s, r) = unbounded();
 
-        let mut receiver = Receiver::new(self.config.receivers.interval);
-        self.register_ping_receivers(&mut receiver);
-        self.register_http_receivers(&mut receiver);
-        let collect_scheduler = thread::spawn(move || receiver.start(s));
+        let mut collector_scheduler = CollectorScheduler::new(self.config.collectors.interval);
+        self.register_ping_collectors(&mut collector_scheduler);
+        self.register_http_collectors(&mut collector_scheduler);
+        let collector_scheduler = thread::spawn(move || collector_scheduler.start(s));
 
         let mut export_scheduler = ExporterScheduler::new();
         self.register_exporters(&mut export_scheduler);
         let export_scheduler = thread::spawn(move || export_scheduler.start(r));
 
-        collect_scheduler
+        collector_scheduler
             .join()
             .expect("The collector scheduler thread has panicked");
         export_scheduler
@@ -37,22 +37,22 @@ impl Uption {
         println!("Uption stopped");
     }
 
-    fn register_ping_receivers(&self, receiver: &mut Receiver) {
-        let ping_config = &self.config.receivers.ping;
+    fn register_ping_collectors(&self, scheduler: &mut CollectorScheduler) {
+        let ping_config = &self.config.collectors.ping;
 
         if ping_config.enabled {
             for host in ping_config.hosts.iter() {
-                receiver.register(Ping::new(host.clone(), 1));
+                scheduler.register(Ping::new(host.clone(), 1));
             }
         }
     }
 
-    fn register_http_receivers(&self, receiver: &mut Receiver) {
-        let http_config = &self.config.receivers.http;
+    fn register_http_collectors(&self, scheduler: &mut CollectorScheduler) {
+        let http_config = &self.config.collectors.http;
 
         if http_config.enabled {
             for url in http_config.urls.iter() {
-                receiver.register(HTTP::new(url.clone(), http_config.timeout));
+                scheduler.register(HTTP::new(url.clone(), http_config.timeout));
             }
         }
     }

--- a/uption.toml
+++ b/uption.toml
@@ -1,14 +1,14 @@
 [general]
 hostname = "uption-host-1"
 
-[receivers]
+[collectors]
 interval = 10
 
-[receivers.ping]
+[collectors.ping]
 enabled = true
 hosts = []
 
-[receivers.http]
+[collectors.http]
 enabled = true
 timeout = 10
 urls = []


### PR DESCRIPTION
- Renamed `Exporter` struct to `ExporterScheduler` and `Sink` trait to `Exporter`.
- Renamed `receivers` module to `collectors` and `Receiver` struct to `CollectorScheduler`.