### PR TITLE
Add ping timeout and get only ping latency

### DIFF
--- a/src/collectors/http.rs
+++ b/src/collectors/http.rs
@@ -44,8 +44,8 @@ impl Collector for HTTP {
         let latency = now.elapsed().as_millis();
 
         let mut message = Message::new("http");
-        message.insert_data("latency", &latency);
-        message.insert_data("status_code", &resp.status_code().to_string());
+        message.insert_data("latency", latency);
+        message.insert_data("status_code", resp.status_code().to_string());
 
         Ok(message)
     }

--- a/src/collectors/ping.rs
+++ b/src/collectors/ping.rs
@@ -9,84 +9,51 @@ use crate::url::Host;
 
 pub struct Ping {
     host: Host,
-    ping_count: u8,
+    timeout: u64,
 }
 
 impl Ping {
-    pub fn new(host: Host, ping_count: u8) -> Ping {
-        Ping { host, ping_count }
+    pub fn new(host: Host, timeout: u64) -> Ping {
+        Ping { host, timeout }
+    }
+
+    fn get_ping_latency(&self) -> f64 {
+        let output = self.execute_ping_on_command_line();
+        self.parse_latency_from_ping_output(&output)
+    }
+
+    fn execute_ping_on_command_line(&self) -> String {
+        let output = Command::new("sh")
+            .arg("-c")
+            .arg(format!(
+                "ping {} -c 1 -w {}",
+                &self.host.to_string(),
+                self.timeout
+            ))
+            .output()
+            .expect("failed to execute process");
+
+        String::from_utf8(output.stdout).expect("Failed to parse")
+    }
+
+    fn parse_latency_from_ping_output(&self, ping_output: &str) -> f64 {
+        let captures = self.latency_regex().captures(ping_output).unwrap();
+        let latency = captures.get(1).map(|m| m.as_str()).unwrap();
+
+        latency.parse().unwrap()
+    }
+
+    fn latency_regex(&self) -> Regex {
+        Regex::new(r#"time=(\d+\.\d+) ms"#).unwrap()
     }
 }
 
 impl Collector for Ping {
     fn collect(&self) -> Result<Message, CollectorError> {
-        let ping_output = execute_ping_on_command_line(self);
-        Ok(parse_ping_output_to_message(ping_output))
+        let latency = self.get_ping_latency();
+
+        let mut message = Message::new("ping");
+        message.insert_data("latency", latency);
+        Ok(message)
     }
-}
-
-fn execute_ping_on_command_line(ping: &Ping) -> String {
-    let output = Command::new("sh")
-        .arg("-c")
-        .arg(format!(
-            "ping {} -c {} -q",
-            ping.host.to_string(),
-            ping.ping_count
-        ))
-        .output()
-        .expect("failed to execute process");
-    std::str::from_utf8(&output.stdout)
-        .expect("Failed to parse")
-        .into()
-}
-
-fn parse_ping_output_to_message(ping_output: String) -> Message {
-    let lines: Vec<&str> = ping_output.lines().rev().collect();
-    let mut message = Message::new("ping");
-
-    let mut fields = parse_packets_line(lines[1]);
-    fields.append(&mut parse_rtt_line(lines[0]));
-
-    for (key, value) in fields.iter() {
-        message.insert_data(key, *value);
-    }
-
-    message
-}
-
-fn parse_packets_line(text: &str) -> Vec<(&str, &str)> {
-    let packets_data = get_packet_line_regex().captures(text).unwrap();
-    vec![
-        ("pkt_tx", packets_data.get(1).map_or("", |m| m.as_str())),
-        ("pkt_rx", packets_data.get(2).map_or("", |m| m.as_str())),
-        ("pkt_loss", packets_data.get(3).map_or("", |m| m.as_str())),
-        ("test_time", packets_data.get(4).map_or("", |m| m.as_str())),
-    ]
-}
-
-fn parse_rtt_line(text: &str) -> Vec<(&str, &str)> {
-    let rtt_data = get_rtt_line_regex().captures(text).unwrap();
-    vec![
-        ("rtt_min", rtt_data.get(1).map_or("", |m| m.as_str())),
-        ("rtt_avg", rtt_data.get(2).map_or("", |m| m.as_str())),
-        ("rtt_max", rtt_data.get(3).map_or("", |m| m.as_str())),
-        ("rtt_mdev", rtt_data.get(4).map_or("", |m| m.as_str())),
-    ]
-}
-
-#[cfg(target_os = "linux")]
-fn get_packet_line_regex() -> Regex {
-    Regex::new(r#"([\d]+)[\s\w]+,\s([\d]+)[\s\w]+,\s([\d]{1,3})%[\s\w]+,[\s\w]+\s([\d]+)"#).unwrap()
-}
-
-#[cfg(target_os = "macos")]
-fn get_packet_line_regex() -> Regex {
-    Regex::new(
-        r#"([\d]+)[\s\w]+[\s\w]+,\s([\d]+)[\s\w]+[\s\w]+,\s([\d]{1,3}\.[\d]+)%[\s\w]+[\s\w]+"#,
-    )
-    .unwrap()
-}
-
-fn get_rtt_line_regex() -> Regex {
-    Regex::new(r#"([\d\.]+?)/([\d\.]+?)/([\d\.]+?)/([\d\.]+)"#).unwrap()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,8 @@ pub struct CollectorsConfig {
 pub struct PingConfig {
     pub enabled: bool,
     pub hosts: Vec<Host>,
+    #[serde(default = "default_timeout")]
+    pub timeout: u64,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/message.rs
+++ b/src/message.rs
@@ -59,9 +59,9 @@ pub enum PayloadValue {
     Float64(f64),
 }
 
-impl From<&String> for PayloadValue {
-    fn from(item: &String) -> Self {
-        PayloadValue::String(item.clone())
+impl From<String> for PayloadValue {
+    fn from(item: String) -> Self {
+        PayloadValue::String(item)
     }
 }
 
@@ -71,75 +71,75 @@ impl From<&str> for PayloadValue {
     }
 }
 
-impl From<&i8> for PayloadValue {
-    fn from(item: &i8) -> Self {
-        PayloadValue::Int8(item.clone())
+impl From<i8> for PayloadValue {
+    fn from(item: i8) -> Self {
+        PayloadValue::Int8(item)
     }
 }
 
-impl From<&i16> for PayloadValue {
-    fn from(item: &i16) -> Self {
-        PayloadValue::Int16(item.clone())
+impl From<i16> for PayloadValue {
+    fn from(item: i16) -> Self {
+        PayloadValue::Int16(item)
     }
 }
 
-impl From<&i32> for PayloadValue {
-    fn from(item: &i32) -> Self {
-        PayloadValue::Int32(item.clone())
+impl From<i32> for PayloadValue {
+    fn from(item: i32) -> Self {
+        PayloadValue::Int32(item)
     }
 }
 
-impl From<&i64> for PayloadValue {
-    fn from(item: &i64) -> Self {
-        PayloadValue::Int64(item.clone())
+impl From<i64> for PayloadValue {
+    fn from(item: i64) -> Self {
+        PayloadValue::Int64(item)
     }
 }
 
-impl From<&i128> for PayloadValue {
-    fn from(item: &i128) -> Self {
-        PayloadValue::Int128(item.clone())
+impl From<i128> for PayloadValue {
+    fn from(item: i128) -> Self {
+        PayloadValue::Int128(item)
     }
 }
 
-impl From<&u8> for PayloadValue {
-    fn from(item: &u8) -> Self {
-        PayloadValue::Uint8(item.clone())
+impl From<u8> for PayloadValue {
+    fn from(item: u8) -> Self {
+        PayloadValue::Uint8(item)
     }
 }
 
-impl From<&u16> for PayloadValue {
-    fn from(item: &u16) -> Self {
-        PayloadValue::Uint16(item.clone())
+impl From<u16> for PayloadValue {
+    fn from(item: u16) -> Self {
+        PayloadValue::Uint16(item)
     }
 }
 
-impl From<&u32> for PayloadValue {
-    fn from(item: &u32) -> Self {
-        PayloadValue::Uint32(item.clone())
+impl From<u32> for PayloadValue {
+    fn from(item: u32) -> Self {
+        PayloadValue::Uint32(item)
     }
 }
 
-impl From<&u64> for PayloadValue {
-    fn from(item: &u64) -> Self {
-        PayloadValue::Uint64(item.clone())
+impl From<u64> for PayloadValue {
+    fn from(item: u64) -> Self {
+        PayloadValue::Uint64(item)
     }
 }
 
-impl From<&u128> for PayloadValue {
-    fn from(item: &u128) -> Self {
-        PayloadValue::Uint128(item.clone())
+impl From<u128> for PayloadValue {
+    fn from(item: u128) -> Self {
+        PayloadValue::Uint128(item)
     }
 }
 
-impl From<&f32> for PayloadValue {
-    fn from(item: &f32) -> Self {
-        PayloadValue::Float32(item.clone())
+impl From<f32> for PayloadValue {
+    fn from(item: f32) -> Self {
+        PayloadValue::Float32(item)
     }
 }
 
-impl From<&f64> for PayloadValue {
-    fn from(item: &f64) -> Self {
-        PayloadValue::Float64(item.clone())
+impl From<f64> for PayloadValue {
+    fn from(item: f64) -> Self {
+        PayloadValue::Float64(item)
     }
 }
 

--- a/src/uption.rs
+++ b/src/uption.rs
@@ -44,7 +44,7 @@ impl Uption {
 
         if ping_config.enabled {
             for host in ping_config.hosts.iter() {
-                scheduler.register(Ping::new(host.clone(), 1));
+                scheduler.register(Ping::new(host.clone(), ping_config.timeout));
             }
         }
     }

--- a/uption.toml
+++ b/uption.toml
@@ -6,6 +6,7 @@ interval = 10
 
 [collectors.ping]
 enabled = true
+timeout = 10
 hosts = ["example.com", "93.184.216.34"]
 
 [collectors.http]


### PR DESCRIPTION
I know I said I was supposed to work with the error handling but I decided to do this change to get only latency of one ping since that changes the ping collector quite a lot. I also added configurable timeout for ping.

At least the regex capture should work on Mac too but I'm not sure about the timeout argument.

I changed the `From` trait implementations for `Message` to take owned value instead of a reference. I was thinking this is better because this way we can avoid unnecessary cloning. If we get a reference, we can't avoid cloning because we need owned value for `Message` struct anyway.