### PR TITLE
Add tags to message

### DIFF
--- a/src/collectors/http.rs
+++ b/src/collectors/http.rs
@@ -37,8 +37,9 @@ impl Collector for HTTP {
         let latency = now.elapsed().as_millis();
 
         let mut message = Message::new("http");
-        message.insert_data("latency", latency);
-        message.insert_data("status_code", resp.status_code().to_string());
+        message.insert_metric("latency", latency);
+        message.insert_metric("status_code", resp.status_code().to_string());
+        message.insert_tag("url", self.url.as_str());
 
         Ok(message)
     }

--- a/src/collectors/mod.rs
+++ b/src/collectors/mod.rs
@@ -28,7 +28,7 @@ impl CollectorScheduler {
         self.collectors.push(Box::new(collector));
     }
 
-    pub fn start(&self, sender: Sender<Message>) {
+    pub fn start(&self, sender: Sender<Message>, hostname: String) {
         if self.collectors.is_empty() {
             println!("No collectors configured!");
             return;
@@ -37,13 +37,15 @@ impl CollectorScheduler {
 
         loop {
             for collector in self.collectors.iter() {
-                let msg = match collector.collect() {
+                let mut msg = match collector.collect() {
                     Ok(msg) => msg,
                     Err(err) => {
                         println!("{}", err);
                         continue;
                     }
                 };
+
+                msg.insert_tag("hostname", &hostname);
 
                 match sender.send(msg) {
                     Ok(msg) => msg,

--- a/src/collectors/ping.rs
+++ b/src/collectors/ping.rs
@@ -72,7 +72,8 @@ impl Collector for Ping {
         let latency = self.get_ping_latency().source("ping_collector")?;
 
         let mut message = Message::new("ping");
-        message.insert_data("latency", latency);
+        message.insert_metric("latency", latency);
+        message.insert_tag("host", &self.host.to_string());
         Ok(message)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct UptionConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct GeneralConfig {
-    hostname: String,
+    pub hostname: String,
 }
 #[derive(Debug, Deserialize)]
 pub struct CollectorsConfig {

--- a/src/exporters/influxdb.rs
+++ b/src/exporters/influxdb.rs
@@ -44,10 +44,17 @@ impl InfluxDB {
 
     fn message_to_line_protocol(&self, msg: &Message) -> String {
         let mut lines = String::new();
-        for (key, value) in msg.payload().iter() {
+
+        let mut tags = String::new();
+        for (key, value) in msg.tags().iter() {
+            tags.push_str(&format!(",{}={}", key, value));
+        }
+
+        for (key, value) in msg.metrics().iter() {
             lines.push_str(&format!(
-                "{} {}={} {}\n",
+                "{}{} {}={} {}\n",
                 msg.source(),
+                tags,
                 key,
                 value,
                 msg.timestamp().timestamp_millis()

--- a/src/uption.rs
+++ b/src/uption.rs
@@ -27,8 +27,9 @@ impl Uption {
         self.register_http_collectors(&mut collector_scheduler);
 
         let builder = thread::Builder::new().name("collector_scheduler".into());
+        let hostname = self.config.general.hostname.to_owned();
         let collector_scheduler = builder
-            .spawn(move || collector_scheduler.start(sender))
+            .spawn(move || collector_scheduler.start(sender, hostname))
             .unwrap();
 
         let mut export_scheduler = self.create_export_scheduler(receiver);


### PR DESCRIPTION
I added tags to message and changed `Message::new` signature so that it is not possible to create a message without any metrics. Additional metrics can be added with `insert_metric` method.

Closes #30 and closes #29.