### PR TITLE
Implement Configure trait and refactor

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -119,3 +119,7 @@ impl UptionConfig {
 fn default_timeout() -> u64 {
     30
 }
+
+pub trait Configure {
+    fn from_config(config: &UptionConfig) -> Self;
+}


### PR DESCRIPTION
I implemented Configure trait to allow constructing schedulers from UptionConfig. I think this makes the implementation a lot cleaner at least in `uption` module.