### PR TITLE
Fix libc version too new in release builds

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -26,7 +26,7 @@ jobs:
 
   build-and-test:
     name: Build crate and run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     needs: verify-version
 
     steps:
@@ -44,6 +44,7 @@ jobs:
           key: ${{ runner.os }}-cargo-registry-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-registry-release-
+            ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo build (release)
         uses: actions/cache@v1
@@ -52,6 +53,7 @@ jobs:
           key: ${{ runner.os }}-cargo-build-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-cargo-build-release-
+            ${{ runner.os }}-cargo-build-
 
       - name: Build (release)
         run: cargo build --release
@@ -61,7 +63,7 @@ jobs:
 
   create-deb-packages:
     name: Create debian packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-16.04
     needs: build-and-test
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -703,6 +703,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
+name = "openssl-src"
+version = "111.9.0+1.1.1g"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2dbe10ddd1eb335aba3780eb2eaa13e1b7b441d2562fd962398740927f39ec4"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +720,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 regex = "1.3"
 url = { version = "2.1", features = ["serde"] }
-reqwest = { version = "0.10", features = ["blocking", "json"] }
+reqwest = { version = "0.10", features = ["blocking", "json", "native-tls-vendored"] }
 config = "0.10"
 rand = "0.7"
 log = "0.4"


### PR DESCRIPTION
Rust binaries use the same libc version as in the host machine it was built. This causes problems with the target machine where Uption is executed has older version of libc. The solution is to build using an older host image.

**Changes**:
- Use Ubuntu 16.04 (EoL in 2021) when building releases.
- Use vendored openssl in reqwest to avoid compilation errors when cross-compiling.
- Restore build cache from non-release cache if not release cache is present.