### PR TITLE
Add ping collector tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,11 @@ jobs:
       - name: Build
         run: cargo build
 
-      - name: Run tests
+      - name: Run unit tests
         run: cargo test
+
+      - name: Run integration tests
+        run: cargo test -- --ignored
 
   lint:
     name: Run linter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Types of changes:
 - Replace `http_req` crate with `reqwest`.
 - Add InfluxDB exporter and HTTP collector tests.
 - Implement logging to a file and stdout.
+- Tests for ping collector.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "95e28fa049fda1c330bcf9d723be7663a899c4679724b34c81e9f5a326aab8cd"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b486ce3ccf7ffd79fdeb678eac06a9e6c09fc88d33836340becb8fffe87c5e33"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chrono"
@@ -459,12 +459,11 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lexical-core"
-version = "0.6.7"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f86d66d380c9c5a685aaac7a11818bdfa1f733198dfd9ec09c70b762cd12ad6f"
+checksum = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
 dependencies = [
  "arrayvec",
- "bitflags",
  "cfg-if",
  "rustc_version",
  "ryu",
@@ -930,6 +929,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rstest"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea1555a95dd3db6095e7695ff1cb173d9d57731209684ef544ead2ff0f6d7077"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "rust-ini"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1265,7 @@ dependencies = [
  "rand",
  "regex",
  "reqwest",
+ "rstest",
  "serde 1.0.106",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ fern = "0.6"
 
 [dev-dependencies]
 mockito = "0.25"
+rstest = "0.6"
 
 [package.metadata.deb]
 license-file = ["LICENSE"]

--- a/src/collectors/ping.rs
+++ b/src/collectors/ping.rs
@@ -77,3 +77,28 @@ impl Collector for Ping {
         Ok(message)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use rstest::*;
+
+    use super::*;
+
+    #[fixture]
+    fn ping_output() -> &'static str {
+        "PING localhost (127.0.0.1) 56(84) bytes of data.
+
+        --- 127.0.0.1 ping statistics ---
+        1 packets transmitted, 1 received, 0% packet loss, time 0ms
+        rtt min/avg/max/mdev = 10.192/10.192/10.192/0.000 ms"
+    }
+
+    #[rstest]
+    #[allow(clippy::float_cmp)]
+    fn ping_output_parsing_successful(ping_output: &str) {
+        let ping = Ping::new("localhost".parse().unwrap(), 1);
+        let result = ping.parse_latency_from_ping_output(ping_output).unwrap();
+
+        assert_eq!(result, 10.192);
+    }
+}

--- a/src/collectors/ping.rs
+++ b/src/collectors/ping.rs
@@ -101,4 +101,15 @@ mod tests {
 
         assert_eq!(result, 10.192);
     }
+
+    #[test]
+    #[ignore]
+    fn ping_collect() {
+        let ping = Ping::new("localhost".parse().unwrap(), 1);
+        let msg = ping.collect().unwrap();
+
+        assert_eq!(msg.source(), "ping");
+        assert!(msg.metrics().get("latency").is_some());
+        assert_eq!(msg.tags()["host"], "localhost");
+    }
 }

--- a/src/url/host.rs
+++ b/src/url/host.rs
@@ -1,12 +1,28 @@
 use std::fmt;
+use std::str;
 
 use serde::de::{self, Visitor};
 use serde::{Deserialize, Deserializer};
-use url::Host as UrlHost;
+use url::{Host as UrlHost, ParseError};
 
 #[derive(Debug, Clone)]
 pub enum Host {
     Host(UrlHost),
+}
+
+impl Host {
+    pub fn parse(input: &str) -> Result<Host, ParseError> {
+        let host = UrlHost::parse(input)?;
+        Ok(Host::Host(host))
+    }
+}
+
+impl str::FromStr for Host {
+    type Err = ParseError;
+
+    fn from_str(input: &str) -> Result<Host, ParseError> {
+        Host::parse(input)
+    }
 }
 
 impl fmt::Display for Host {


### PR DESCRIPTION
I added a simple test for ping collector. I couldn't think of an easy way to mock calling ping so I tested ping output parsing separately and created a ping collect test that is ignored by default. I'm thinking that we could use the ignored tests for integration testing and ignored tests could make actual network calls.

I also added rstest dependency. Fixtures don't seem to be so useful in Rust because it t is not possible to replace existing fixtures for different tests and there is no inheritance. However, I like that it is explicit in the test function signature which "helpers" are used. Also, this functionality provides some flexibility with fixtures: https://github.com/la10736/rstest#more

Related to #20 