### PR TITLE
Add a changelog

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   verify-version:
-    name: Verify that tagged version matches crate version
+    name: Verify that version and changelog are updated
     runs-on: ubuntu-latest
 
     steps:
@@ -23,6 +23,11 @@ jobs:
             exit 1
           fi
         shell: bash
+
+      - name: Verify changelog entry
+        run: |
+          export CRATE_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+          grep -E "^## v$CRATE_VERSION - [[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}$" CHANGELOG.md
 
   build-and-test:
     name: Build crate and run tests
@@ -143,9 +148,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set version environment variable
+      - name: Set version and changelog environment variables
+        id: variables
         run: |
-          echo "::set-env name=version::$(cargo pkgid | cut -d# -f2 | cut -d: -f2)"
+          export CRATE_VERSION=$(cargo pkgid | cut -d# -f2 | cut -d: -f2)
+          echo "::set-env name=version::$CRATE_VERSION"
+
+          export MAJOR=$(echo $CRATE_VERSION | cut -d'.' -f1)
+          export MINOR=$(echo $CRATE_VERSION | cut -d'.' -f2)
+          export PATCH=$(echo $CRATE_VERSION | cut -d'.' -f3)
+          export CHANGELOG=$(awk -v pat="## v$MAJOR\.$MINOR\.$PATCH - " '($0 ~ pat){flag=1; next} /## v[0-9]\.[0-9]\.[0-9] - /{flag=0} flag' CHANGELOG.md)
+
+          # Hack to support multiline variables in GA
+          CHANGELOG="${CHANGELOG//'%'/'%25'}"
+          CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+          CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+          echo "::set-output name=changelog::$CHANGELOG"
 
       - name: Create release
         id: create_release
@@ -155,8 +173,7 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Uption ${{ github.ref }}
-          body: |
-            Uption ${{ github.ref }}
+          body: ${{ steps.variables.outputs.changelog }}
           draft: false
           prerelease: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Uption changelog
+
+This project follows semantic versioning.
+
+Types of changes:
+
+- **Added**: New features.
+- **Changed**: Changes in existing functionality.
+- **Deprecated**: Soon-to-be removed features.
+- **Removed**: Removed features.
+- **Fixed**: Bug fixes.
+- **Security**: Vulnerabilities.
+- **Infrastructure**: Changes in build or deployment infrastructure.
+- **Documentation**: Changes in documentation.
+
+## [Unreleased]
+
+### Added
+
+- Replace `http_req` crate with `reqwest`.
+- Add InfluxDB exporter and HTTP collector tests.
+- Implement logging to a file and stdout.
+
+### Fixed
+
+- Libc version too new in release builds.
+
+### Infrastructure
+
+- Add lint and format steps in CI.
+- Add scheduled dependency security audit.
+- Build and test in release mode when making a release.
+
+## v0.3.1 - 2020-04-14
+
+### Changed
+
+- Update dependencies.
+
+### Fixed
+
+- Fix Debian package replaces configuration files.
+
+## v0.3.0 - 2020-04-14
+
+### Added
+
+- Order inserted tags and metrics when exporting.
+- Support tags in exported messages.
+- Add hostname tag to exported messages.
+
+### Changed
+
+- Export message to InfluxDB as a single line.
+
+### Infrastructure
+
+- Add CI workflow to build Debian packages automatically.
+
+### Documentation
+
+- Add installation instructions to README.md.
+
+## v0.2.1 - 2020-04-06
+
+### Fixed
+
+- Ping parsing fails if latency more than 99ms.
+
+## v0.2.0 - 2020-04-05
+
+### Added
+
+- Error handling improvements.
+- Exporter scheduler retry logic.
+
+## v0.1.0 - 2020-03-30
+
+### Added
+
+- HTTP collector.
+- Ping collector.
+- Stdout exporter.
+- InfluxDB exporter.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 All contributors to Uption
+Copyright (c) 2020 Olli Paakkunainen, Adarsh Krishnan
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
I added CHANGELOG.md and modified release workflow to update new changelog entry automatically to Github Release.

I found the hack for multiline Github Actions variables here: https://github.community/t5/GitHub-Actions/set-output-Truncates-Multiline-Strings/td-p/37870

Closes #50 