### PR TITLE
Rename logger config section to logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Types of changes:
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `logger` config section to `logging`.
+
 ### Documentation
 
 - Add links to documentation.

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,7 +11,7 @@ pub struct UptionConfig {
     pub general: GeneralConfig,
     pub collectors: CollectorsConfig,
     pub exporters: ExportersConfig,
-    pub logger: LoggerConfig,
+    pub logging: LoggerConfig,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -48,7 +48,7 @@ impl Logger {
 
 impl Configure for Logger {
     fn from_config(config: &UptionConfig) -> Self {
-        let logger_config = &config.logger;
+        let logger_config = &config.logging;
         let logger = Logger::new(logger_config.level);
 
         let logger = if logger_config.enable_stdout {

--- a/uption.toml
+++ b/uption.toml
@@ -1,7 +1,7 @@
 [general]
 hostname = "uption-host-1"
 
-[logger]
+[logging]
 level = "info"
 enable_stdout = true
 # log_file = "uption.log"

--- a/uption.toml
+++ b/uption.toml
@@ -4,7 +4,6 @@ hostname = "uption-host-1"
 [logging]
 level = "info"
 enable_stdout = true
-# log_file = "uption.log"
 
 [collectors]
 interval = 10


### PR DESCRIPTION
Renamed `logger` config section to `logging`. I think "logging" configuration makes much more sense than "logger" configuration since we are able to configure multiple loggers. I already renamed this in wiki.