### PR TITLE
Require up to date lock file in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      # Workaround for https://github.com/actions/cache/issues/133
-      - name: Fix cargo caching
-        run: sudo chown -R $(whoami):$(id -ng) ~/.cargo/
-
       - name: Cache cargo registry
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             ${{ runner.os }}-cargo-build-
 
       - name: Build
-        run: cargo build
+        run: cargo build --locked
 
       - name: Run unit tests
         run: cargo test

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build (release)
-        run: cargo build --release
+        run: cargo build --release --locked
 
       - name: Run tests (release)
         run: cargo test --release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Types of changes:
 
 - Rename `logger` config section to `logging`.
 
+### Infrastructure
+
+- Require up to date lock file in CI.
+
 ### Documentation
 
 - Add links to documentation.


### PR DESCRIPTION
I added `--locked` argument to `cargo build` calls in CI workflows. This prevents CI from to silently updating the lock file if it is out of date.