### PR TITLE
Add wireless interface collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Types of changes:
 ### Added
 
 - Add default values to all configuration options.
+- Implement wireless interface collector.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -80,10 +80,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "buffering"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64c1c8b8b4ae23f4bfb012a67b943c992f10ff88cd5d37fb38be92209f2aff2"
+
+[[package]]
 name = "bumpalo"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e8c087f005730276d1096a652e92a8bacee2e2472bcc9715a74d2bec38b5820"
+
+[[package]]
+name = "byteorder"
+version = "1.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
@@ -733,6 +745,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "neli"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e85e9782bd259f916321a71dc0292aa6b0fbb63ff949a6f5e45167b793b6b6d3"
+dependencies = [
+ "buffering",
+ "byteorder",
+ "libc",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -741,6 +764,15 @@ dependencies = [
  "cfg-if 0.1.10",
  "libc",
  "winapi 0.3.9",
+]
+
+[[package]]
+name = "netlink_wi"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8b9c5107a7fa650b5bef297b8985a90a862e116c137e8a4a8a54be97f436c4"
+dependencies = [
+ "neli",
 ]
 
 [[package]]
@@ -1657,6 +1689,7 @@ dependencies = [
  "fern",
  "log",
  "mockito",
+ "netlink_wi",
  "rand 0.8.0",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ reqwest = { version = "0.10", features = ["blocking", "json", "native-tls-vendor
 serde = { version = "1.0", features = ["derive"] }
 trust-dns-client = { version = "0.20", default-features = false }
 url = { version = "2.1", features = ["serde"] }
+netlink_wi = "0.3"
 
 [dev-dependencies]
 mockito = "0.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,8 @@ authors = [
   "Olli Paakkunainen <olli@paakkunainen.fi>",
   "Adarsh Krishnan <adarshk7@gmail.com>",
 ]
-categories = ["command-line-utilities"]
 description = """
-A tool to collect and export network performance metrics on devices like
-WLAN Pi and Raspberry Pi.
+A tool to collect and export network performance metrics on Linux devices.
 """
 documentation = "https://github.com/uption/uption/wiki"
 edition = "2018"

--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 [![CI](https://github.com/uption/uption/workflows/CI/badge.svg)](https://github.com/uption/uption/actions?query=workflow%3ACI)
 [![docs](https://img.shields.io/badge/docs-Uption%20wiki-blue)](https://github.com/uption/uption/wiki)
 
-A tool to collect and export network performance metrics on devices like WLAN Pi and Raspberry Pi.
+A tool to collect and export network performance metrics on Linux devices.
 This tool was inspired by [wiperf](https://github.com/wifinigel/wiperf) project.
 
 ## Documentation
 
-Documentation can be found from [Uption wiki](https://github.com/uption/uption/wiki).
+Uption has a concept of _collectors_ and _exporters_. Collectors generate metrics based on different tests and exporters export the generated data. See documentation for all the supported collectors and exporters. Documentation can be found from [Uption wiki](https://github.com/uption/uption/wiki).
 
 ## Installation
 
@@ -37,44 +37,6 @@ dpkg -i uption_x.y.z_amd64.deb
 sudo systemctl enable uption
 sudo systemctl start uption
 ```
-
-## Project status
-
-🚧 This project is in very early stage of development 🚧
-
-### Features
-
-Uption has a concept of _collectors_ and _exporters_. Collectors generate metrics based on different tests and exporters export the generated data.
-
-#### Exporters
-
-- [x] Stdout
-- [x] InfluxDB
-- [x] Logger
-
-#### Collectors
-
-- [x] DNS
-- [x] HTTP
-- [x] Ping
-
-### Feature parity with Wiperf
-
-#### Exporters
-
-- [ ] Splunk ([issue #13](https://github.com/uption/uption/issues/13))
-- [ ] JSON file ([issue #11](https://github.com/uption/uption/issues/11))
-- [ ] CSV file ([issue #12](https://github.com/uption/uption/issues/12))
-
-#### Collectors
-
-- [ ] DHCP ([issue #14](https://github.com/uption/uption/issues/14))
-- [x] DNS
-- [x] HTTP
-- [ ] Iperf3 ([issue #16](https://github.com/uption/uption/issues/16))
-- [ ] Ookla Speedtest ([issue #17](https://github.com/uption/uption/issues/17))
-- [x] Ping
-- [ ] Wireless adapter ([issue #18](https://github.com/uption/uption/issues/18))
 
 ## Contributions
 

--- a/src/collectors/dns.rs
+++ b/src/collectors/dns.rs
@@ -41,14 +41,14 @@ impl Dns {
 }
 
 impl Collector for Dns {
-    fn collect(&self) -> Result<Message> {
+    fn collect(&self) -> Result<Vec<Message>> {
         let latency = self.make_dns_query().set_source("dns_collector")?;
 
         let mut message = Message::new("dns");
         message.insert_metric("latency", latency);
         message.insert_tag("dns_server", &self.server.to_string());
         message.insert_tag("host", &self.host.to_string());
-        Ok(message)
+        Ok(vec![message])
     }
 }
 
@@ -64,7 +64,7 @@ mod tests {
             "www.google.com".parse().unwrap(),
             1,
         );
-        let msg = dns.collect().unwrap();
+        let msg = dns.collect().unwrap().pop().unwrap();
 
         assert_eq!(msg.source(), "dns");
         assert!(msg.metrics().get("latency").is_some());

--- a/src/collectors/ping.rs
+++ b/src/collectors/ping.rs
@@ -75,13 +75,13 @@ impl Ping {
 }
 
 impl Collector for Ping {
-    fn collect(&self) -> Result<Message> {
+    fn collect(&self) -> Result<Vec<Message>> {
         let latency = self.get_ping_latency().set_source("ping_collector")?;
 
         let mut message = Message::new("ping");
         message.insert_metric("latency", latency);
         message.insert_tag("host", &self.host.to_string());
-        Ok(message)
+        Ok(vec![message])
     }
 }
 
@@ -113,7 +113,7 @@ mod tests {
     #[ignore]
     fn ping_collect() {
         let ping = Ping::new("localhost".parse().unwrap(), Timeout(1));
-        let msg = ping.collect().unwrap();
+        let msg = ping.collect().unwrap().pop().unwrap();
 
         assert_eq!(msg.source(), "ping");
         assert!(msg.metrics().get("latency").is_some());

--- a/src/collectors/wireless.rs
+++ b/src/collectors/wireless.rs
@@ -1,0 +1,103 @@
+//! Wireless interface collector gathers information about wireless interfaces
+//! from the operating system.
+use netlink_wi::{AttrParseError, NlSocket, WirelessInterface, WirelessStation};
+
+use super::Collector;
+use crate::error::{Error, Result, ResultError};
+use crate::message::Message;
+
+pub struct Wireless {}
+
+impl Wireless {
+    pub fn new() -> Self {
+        Self {}
+    }
+
+    fn get_interfaces(&self) -> Result<Vec<WirelessInterface>> {
+        let socket = NlSocket::connect()?;
+        let interfaces = socket
+            .list_interfaces()?
+            .into_iter()
+            .collect::<std::result::Result<Vec<_>, AttrParseError>>()?;
+        if interfaces.is_empty() {
+            return Err(Error::new("No wireless interfaces found"));
+        }
+        Ok(interfaces)
+    }
+
+    fn get_stations(&self, if_index: u32) -> Result<Vec<WirelessStation>> {
+        let socket = NlSocket::connect()?;
+        let stations = socket
+            .list_stations(if_index)?
+            .into_iter()
+            .collect::<std::result::Result<Vec<_>, AttrParseError>>()?;
+        Ok(stations)
+    }
+}
+
+impl Collector for Wireless {
+    fn collect(&self) -> Result<Vec<Message>> {
+        let interfaces = self.get_interfaces().set_source("wireless_collector")?;
+        let mut messages = Vec::new();
+        for interface in interfaces {
+            let mut message = Message::new("wireless_interface");
+            message.insert_tag("name", &interface.name);
+            message.insert_tag("interface_mac", &interface.mac.to_string());
+            if let Some(ssid) = interface.ssid {
+                message.insert_tag("ssid", &ssid);
+            }
+            if let Some(frequency) = interface.frequency {
+                message.insert_metric("frequency", frequency);
+            }
+            if let Some(channel_width) = interface.channel_width {
+                message.insert_metric("channel_width", Into::<u32>::into(channel_width));
+            }
+            if let Some(tx_power) = interface.tx_power {
+                message.insert_metric("tx_power", tx_power);
+            }
+            messages.push(message);
+
+            let stations = self.get_stations(interface.interface_index)?;
+            for station in stations {
+                let mut message = Message::new("wireless_station");
+                message.insert_tag("interface_mac", &interface.mac.to_string());
+                message.insert_tag("station_mac", &station.mac.to_string());
+                if let Some(signal) = station.signal {
+                    message.insert_metric("signal_strength", signal);
+                }
+                if let Some(rx_bytes) = station.rx_bytes64 {
+                    message.insert_metric("rx_bytes", rx_bytes);
+                }
+                if let Some(tx_bytes) = station.tx_bytes64 {
+                    message.insert_metric("tx_bytes", tx_bytes);
+                }
+                if let Some(rx_packets) = station.rx_packets {
+                    message.insert_metric("rx_packets", rx_packets);
+                }
+                if let Some(tx_packets) = station.tx_packets {
+                    message.insert_metric("tx_packets", tx_packets);
+                }
+                if let Some(tx_retries) = station.tx_retries {
+                    message.insert_metric("tx_retries", tx_retries);
+                }
+                if let Some(tx_failed) = station.tx_failed {
+                    message.insert_metric("tx_failed", tx_failed);
+                }
+                if let Some(rateinfo) = station.rx_bitrate {
+                    message.insert_metric("rx_bitrate", rateinfo.bitrate);
+                    message.insert_metric("rx_mcs", rateinfo.mcs);
+                    message
+                        .insert_metric("rx_connection_type", rateinfo.connection_type.to_string());
+                }
+                if let Some(rateinfo) = station.tx_bitrate {
+                    message.insert_metric("tx_bitrate", rateinfo.bitrate);
+                    message.insert_metric("tx_mcs", rateinfo.mcs);
+                    message
+                        .insert_metric("tx_connection_type", rateinfo.connection_type.to_string());
+                }
+                messages.push(message);
+            }
+        }
+        Ok(messages)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -101,6 +101,7 @@ pub struct CollectorsConfig {
     pub dns: DnsConfig,
     pub http: HttpConfig,
     pub ping: PingConfig,
+    pub wireless: WirelessConfig,
 }
 
 impl Validate for CollectorsConfig {
@@ -113,6 +114,7 @@ impl Validate for CollectorsConfig {
         self.dns.validate()?;
         self.http.validate()?;
         self.ping.validate()?;
+        self.wireless.validate()?;
         Ok(())
     }
 }
@@ -124,6 +126,7 @@ impl Default for CollectorsConfig {
             dns: DnsConfig::default(),
             http: HttpConfig::default(),
             ping: PingConfig::default(),
+            wireless: WirelessConfig::default(),
         }
     }
 }
@@ -184,6 +187,18 @@ impl Validate for PingConfig {
                 "ping.hosts can't be empty".to_string(),
             ));
         }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(default)]
+pub struct WirelessConfig {
+    pub enabled: bool,
+}
+
+impl Validate for WirelessConfig {
+    fn validate(&self) -> Result<(), ConfigError> {
         Ok(())
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,6 +8,7 @@ fn test_uption_start_with_empty_config() {
         .unwrap()
         .env("UPTION_COLLECTORS_PING_ENABLED", "false")
         .env("UPTION_COLLECTORS_HTTP_ENABLED", "false")
+        .env("UPTION_COLLECTORS_WIRELESS_ENABLED", "false")
         .timeout(std::time::Duration::from_secs(1))
         .output()
         .unwrap();

--- a/uption.toml
+++ b/uption.toml
@@ -22,5 +22,8 @@ dns_servers = []
 enabled = false
 hosts = []
 
+[collectors.wireless]
+enabled = false
+
 [exporters]
 exporter = "stdout"


### PR DESCRIPTION
## Description

Add wireless interface collector.

```
> cargo run
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/uption`
[uption-host-1] INFO [2020-11-18T13:03:06.306565202+00:00] Uption v0.5.0 started
[uption-host-1] INFO [2020-11-18T13:03:06.306685035+00:00] Collector scheduler started
[uption-host-1] INFO [2020-11-18T13:03:06.306703493+00:00] Exporter scheduler started
[2020-11-18T13:03:06.306919032+00:00] [source="wireless" hostname="uption-host-1" mac="9F:B8:F3:D4:23:B5" name="wlp0s20f3" ssid="MySSID"] channel_width="80" frequency="5200" tx_power="2200"
[2020-11-18T13:03:16.307297599+00:00] [source="wireless" hostname="uption-host-1" mac="9F:B8:F3:D4:23:B5" name="wlp0s20f3" ssid="MySSID"] channel_width="80" frequency="5200" tx_power="2200"
[2020-11-18T13:03:26.308287239+00:00] [source="wireless" hostname="uption-host-1" mac="9F:B8:F3:D4:23:B5" name="wlp0s20f3" ssid="MySSID"] channel_width="80" frequency="5200" tx_power="2200"
```

Closes #18

## Checklist

- [x] Changelog has been updated.
- [ ] Unit tests have been updated.
- [x] Related documentation in wiki has been updated.
